### PR TITLE
Make common role work on newer Ubuntu (signed-by + repo codename override)

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -3,4 +3,4 @@
 # Debian/Ubuntu. Defaults to the host's running release; override when the
 # upstream repo does not yet ship packages for the running release (e.g.
 # Ubuntu 26.04 hosts using the 24.04 / noble repo).
-stns_apt_distribution_release: "{{ ansible_distribution_release }}"
+stns_apt_distribution_release: "{{ ansible_facts['distribution_release'] }}"

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+# Distribution codename used to construct the STNS apt repository URL on
+# Debian/Ubuntu. Defaults to the host's running release; override when the
+# upstream repo does not yet ship packages for the running release (e.g.
+# Ubuntu 26.04 hosts using the 24.04 / noble repo).
+stns_apt_distribution_release: "{{ ansible_distribution_release }}"

--- a/roles/common/tasks/repo-debian.yml
+++ b/roles/common/tasks/repo-debian.yml
@@ -1,11 +1,19 @@
 ---
+- name: (Debian/Ubuntu) ensure /etc/apt/keyrings exists
+  ansible.builtin.file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: "0755"
+  become: true
 - name: (Debian/Ubuntu) add STNS repository key
-  ansible.builtin.apt_key:
+  ansible.builtin.get_url:
     url: https://repo.stns.jp/gpg/GPG-KEY-stns
-    state: present
+    dest: /etc/apt/keyrings/stns.asc
+    mode: "0644"
   become: true
 - name: (Debian/Ubuntu) add STNS repository
   ansible.builtin.apt_repository:
     filename: stns
-    repo: "deb https://repo.stns.jp/{{ ansible_distribution_release }}/ stns {{ ansible_distribution_release }}"
-    mode: 0644
+    repo: "deb [signed-by=/etc/apt/keyrings/stns.asc] https://repo.stns.jp/{{ ansible_distribution_release }}/ stns {{ ansible_distribution_release }}"
+    mode: "0644"
+  become: true

--- a/roles/common/tasks/repo-debian.yml
+++ b/roles/common/tasks/repo-debian.yml
@@ -14,6 +14,6 @@
 - name: (Debian/Ubuntu) add STNS repository
   ansible.builtin.apt_repository:
     filename: stns
-    repo: "deb [signed-by=/etc/apt/keyrings/stns.asc] https://repo.stns.jp/{{ ansible_distribution_release }}/ stns {{ ansible_distribution_release }}"
+    repo: "deb [signed-by=/etc/apt/keyrings/stns.asc] https://repo.stns.jp/{{ stns_apt_distribution_release }}/ stns {{ stns_apt_distribution_release }}"
     mode: "0644"
   become: true


### PR DESCRIPTION
## Summary
This PR contains two related fixes that together let the `common` role install STNS on Ubuntu releases newer than 22.04.

### 1. Replace deprecated `apt_key` with a `signed-by` keyring file
- `ansible.builtin.apt_key` relies on the `apt-key` binary, which has been deprecated since Debian 11 / Ubuntu 22.04 and removed in Ubuntu 24.04+. On those releases the role fails with `Failed to find required executable "apt-key"`.
- Switch to the modern `signed-by=` pattern: download the GPG key to `/etc/apt/keyrings/stns.asc` with `get_url` and reference it from the `apt_repository` repo line.
- The published key at `https://repo.stns.jp/gpg/GPG-KEY-stns` is ASCII-armored, so apt reads `.asc` directly without `gpg --dearmor`.

### 2. Add `stns_apt_distribution_release` variable
- The repo URL/suite was hardcoded to `ansible_distribution_release`. When a new Ubuntu release ships before `https://repo.stns.jp/<codename>/` exists (e.g. Ubuntu 26.04 / resolute), `apt update` fails with `Release file ... does not have a Release file`.
- Introduce `stns_apt_distribution_release` (default: `{{ ansible_distribution_release }}`) so users can point a newer host at the most recent supported codename (e.g. `noble`) until upstream packages are available.

## Compatibility
- `signed-by=` is supported on apt 1.8+ (Debian 10+, Ubuntu 18.04+).
- The default value of `stns_apt_distribution_release` preserves the previous behavior, so this is a non-breaking change for existing users.
- Existing `molecule/ubuntu-jammy.Dockerfile` is unaffected.

## Test plan
- [ ] Molecule on ubuntu-jammy passes (CI)
- [x] Manual run on Ubuntu 24.04+ no longer fails on the apt-key step
- [ ] Manual run on Ubuntu 26.04 with `stns_apt_distribution_release: noble` succeeds end-to-end